### PR TITLE
fix: remove local dev credentials from compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ dist
 
 # Local Development
 .DS_Store
+.env.local.compose
+localDevelopment/postgres/prefect-api-keys-table.local.csv

--- a/README.md
+++ b/README.md
@@ -89,6 +89,33 @@ docker build -t prefect-auth-proxy .
 docker run -d -p 3000:3000 --env-file ./.env --name auth-proxy prefect-auth-proxy
 ```
 
+#### Local Development with Docker Compose
+
+For local Docker Compose usage, generate the local-only password file and CSV scaffold first:
+
+```bash
+./scripts/start-local.sh --prepare-only
+```
+
+This creates:
+
+- `.env.local.compose` with a generated `LOCAL_POSTGRES_PASSWORD`
+- `localDevelopment/postgres/prefect-api-keys-table.local.csv`
+
+Then add one or more local Prefect API key rows to `localDevelopment/postgres/prefect-api-keys-table.local.csv` and start the stack:
+
+```bash
+./scripts/start-local.sh
+```
+
+If Postgres was already initialized, run `docker compose down -v` before restarting so the CSV seed data is reloaded.
+
+Example CSV row:
+
+```csv
+"localDev","{""GET"": [""api/*""]}","<generated api key>",2026-01-01 00:00:00.000,2027-01-01 00:00:00.000,2026-01-01 00:00:00.000,2026-01-01 00:00:00.000,"localDev","localDev"
+```
+
 ### Running the service
 
 This is a typical node.js application. So you can simply clone this repo and run.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
       # - ALLOW_PUBLIC_ACCESS=false
       - DB_HOST=postgres
       - DB_USER=postgres
-      - DB_PASSWORD=LocalDevelopment
+      - DB_PASSWORD=${LOCAL_POSTGRES_PASSWORD:?Run scripts/start-local.sh first}
       - DB_DATABASE=postgres
     links:
       - postgres
@@ -39,7 +39,7 @@ services:
   postgres:
     image: postgres
     environment:
-      POSTGRES_PASSWORD: LocalDevelopment
+      POSTGRES_PASSWORD: ${LOCAL_POSTGRES_PASSWORD:?Run scripts/start-local.sh first}
     volumes:
       - ./localDevelopment/postgres:/docker-entrypoint-initdb.d
     ports:

--- a/localDevelopment/postgres/init.sql
+++ b/localDevelopment/postgres/init.sql
@@ -11,6 +11,6 @@ CREATE TABLE prefect_api_keys (
 );
 
 COPY prefect_api_keys
-FROM '/docker-entrypoint-initdb.d/prefect-api-keys-table.csv'
+FROM '/docker-entrypoint-initdb.d/prefect-api-keys-table.local.csv'
 DELIMITER ','
 CSV HEADER;

--- a/localDevelopment/postgres/prefect-api-keys-table.csv
+++ b/localDevelopment/postgres/prefect-api-keys-table.csv
@@ -1,3 +1,0 @@
-"user_id","scopes","api_key","key_issu_dt","key_expr_dt","creatd_dt","last_updatd_dt","creatd_by","last_updatd_by"
-localDev,"{""GET"":[""api/flows/*"",""api/deployments/*""],""POST"":[""api/*""]}",EXnPWYVr7r6uo642NxVo,2024-01-01 00:00:00.000,2027-01-01 00:00:00.000,2024-01-01 00:00:00.000,2024-01-01 00:00:00.000,localDev,localDev
-localDev2,"{""GET"":[""api/*""],""POST"":[""api/*""],""DELETE"":[""api/*""]}",Kj8dF3nQw9pLm2xTv5Rs,2024-01-01 00:00:00.000,2027-01-01 00:00:00.000,2024-01-01 00:00:00.000,2024-01-01 00:00:00.000,localDev,localDev

--- a/localDevelopment/postgres/prefect-api-keys-table.example.csv
+++ b/localDevelopment/postgres/prefect-api-keys-table.example.csv
@@ -1,0 +1,1 @@
+"user_id","scopes","api_key","key_issu_dt","key_expr_dt","creatd_dt","last_updatd_dt","creatd_by","last_updatd_by"

--- a/scripts/start-local.sh
+++ b/scripts/start-local.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+ENV_FILE="${REPO_ROOT}/.env.local.compose"
+CSV_TEMPLATE="${REPO_ROOT}/localDevelopment/postgres/prefect-api-keys-table.example.csv"
+CSV_FILE="${REPO_ROOT}/localDevelopment/postgres/prefect-api-keys-table.local.csv"
+PREPARE_ONLY=false
+
+if [[ "${1:-}" == "--prepare-only" ]]; then
+  PREPARE_ONLY=true
+  shift
+fi
+
+generate_password() {
+  python3 - <<'PY'
+import secrets
+import string
+
+alphabet = string.ascii_letters + string.digits
+print(''.join(secrets.choice(alphabet) for _ in range(32)))
+PY
+}
+
+ensure_env_file() {
+  if [[ -f "${ENV_FILE}" ]]; then
+    return
+  fi
+
+  cat > "${ENV_FILE}" <<EOF
+LOCAL_POSTGRES_PASSWORD=$(generate_password)
+EOF
+
+  echo "Created ${ENV_FILE} with a generated LOCAL_POSTGRES_PASSWORD."
+}
+
+ensure_local_csv() {
+  if [[ -f "${CSV_FILE}" ]]; then
+    return
+  fi
+
+  cp "${CSV_TEMPLATE}" "${CSV_FILE}"
+  echo "Created ${CSV_FILE}. Add local Prefect API key rows before relying on authenticated requests."
+}
+
+print_next_steps() {
+  local password
+  password="$(grep '^LOCAL_POSTGRES_PASSWORD=' "${ENV_FILE}" | cut -d'=' -f2-)"
+
+  echo
+  echo "Local development files are ready:"
+  echo "  Env file: ${ENV_FILE}"
+  echo "  API key CSV: ${CSV_FILE}"
+  echo
+  echo "Generated local Postgres password: ${password}"
+  echo
+  echo "Next steps:"
+  echo "  1. Add one or more local API key rows to ${CSV_FILE}."
+  echo "  2. If Postgres was already initialized, run 'docker compose down -v' before restarting so seed data reloads."
+  echo "  3. Re-run this script without --prepare-only to start the local stack."
+}
+
+run_compose() {
+  local compose_cmd=()
+
+  if docker compose version >/dev/null 2>&1; then
+    compose_cmd=(docker compose)
+  elif command -v docker-compose >/dev/null 2>&1; then
+    compose_cmd=(docker-compose)
+  else
+    echo "Docker Compose is required but was not found." >&2
+    exit 1
+  fi
+
+  "${compose_cmd[@]}" --env-file "${ENV_FILE}" up --build "$@"
+}
+
+ensure_env_file
+ensure_local_csv
+print_next_steps
+
+if [[ "${PREPARE_ONLY}" == true ]]; then
+  exit 0
+fi
+
+run_compose "$@"


### PR DESCRIPTION
## Summary
- remove the hard-coded local Postgres password from docker-compose and source it from a generated local env file
- replace the tracked local API key CSV with an example file plus a gitignored local CSV used by Postgres init
- add a local bootstrap script that prepares local-only files and prints setup instructions before starting Docker Compose

## Testing
- bash -n scripts/start-local.sh
- ./scripts/start-local.sh --prepare-only